### PR TITLE
Compare eval result with 'string zero' instead of 'zero'

### DIFF
--- a/rplugin/python3/denite/source/quickfix.py
+++ b/rplugin/python3/denite/source/quickfix.py
@@ -18,7 +18,7 @@ class Source(Base):
                     r'containedin=deniteSource_QuickfixHeader')
     self.vim.command(r'syntax match deniteSource_QuickfixPosition /\v\|\zs.{-}\ze\|/ contained ' +
                     r'containedin=deniteSource_QuickfixHeader')
-    if self.vim.eval('exists("g:grep_word")'):
+    if self.vim.eval('exists("g:grep_word")') != '0':
       pattern = re.escape(self.vim.eval('g:grep_word'))
       self.vim.command(r'syntax match deniteSource_QuickfixWord /' +pattern+ '/')
 


### PR DESCRIPTION
vim.eval returns a sting, even if the result is an integer (:help python-eval)
Because any non-empty string evaluates to True in python, the plugin
always thought "g:grep_word" was set, causing errors if this was not the
case