### PR TITLE
Change quickfix filename highlight to Directory

### DIFF
--- a/rplugin/python3/denite/source/quickfix.py
+++ b/rplugin/python3/denite/source/quickfix.py
@@ -26,7 +26,7 @@ class Source(Base):
 
   def highlight(self):
     self.vim.command('highlight default link deniteSource_QuickfixWord Search')
-    self.vim.command('highlight default link deniteSource_QuickfixName Identifier')
+    self.vim.command('highlight default link deniteSource_QuickfixName Directory')
     self.vim.command('highlight default link deniteSource_QuickfixPosition LineNr')
 
 


### PR DESCRIPTION
This partially fixes #4. 
One we still need to fix is the fact that were there is no line or column number the default vim/nvim quickfix behaviour is to show `||` instead of `|0 col 0|`.